### PR TITLE
HOTFIX: Param store issues

### DIFF
--- a/handlers/static/static.go
+++ b/handlers/static/static.go
@@ -105,3 +105,26 @@ func HandleStaticALB(ctx context.Context, req events.ALBTargetGroupRequest) (*ev
 	// found here is being handled by another handler
 	return nil, nil
 }
+
+func GetResponseByPath(ctx context.Context, path string) (*events.ALBTargetGroupResponse, error) {
+
+	fd, ok := staticURLs[path]
+
+	if ok {
+		resp := &events.ALBTargetGroupResponse{
+			StatusCode:        http.StatusOK,
+			StatusDescription: http.StatusText(http.StatusOK),
+			Body:              fd.Contents,
+			IsBase64Encoded:   fd.IsBinary,
+			Headers: map[string]string{
+				"Content-Type":  fd.MimeType,
+				"Cache-Control": "public, max-age=604800, immutable",
+			},
+		}
+		return resp, nil
+	}
+	// This returns a `nil` error when the path isn't found, as this is by design meant
+	// to be called before any other path handling.  The assumption is that any path not
+	// found here is being handled by another handler
+	return nil, nil
+}


### PR DESCRIPTION
We were only reading the first 10 results from a param store query, and
not actually using the paged results.  This changes the logic to do the
paged requests, so we don't miss anything.

Also, a method was  added to the static asset lib to allow for
retrieving a specific page.
